### PR TITLE
Fix for latest headset update

### DIFF
--- a/91-pulseaudio-steelseries-arctis-7.rules
+++ b/91-pulseaudio-steelseries-arctis-7.rules
@@ -1,2 +1,3 @@
 ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1260", ENV{PULSE_PROFILE_SET}="steelseries-arctis-7-usb-audio.conf"
+ATTRS{idVendor}=="1038", ATTRS{idProduct}=="12ad", ENV{PULSE_PROFILE_SET}="steelseries-arctis-7-usb-audio.conf"
 


### PR DESCRIPTION
the latest steelseries update changed the idProduct from 1260 to 12ad.